### PR TITLE
Don't release `target.'cfg(any())'.dependencies`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
       - name: rustup default stable
         run: rustup default stable
+      - name: Set dependencies in Cargo.toml
+        run: |
+          echo >> Cargo.toml
+          cat Cargo.minimal-versions.toml >> Cargo.toml
       - name: cargo update -Zminimal-versions
         run: cargo +nightly update -Zminimal-versions
       - name: cargo test

--- a/Cargo.minimal-versions.toml
+++ b/Cargo.minimal-versions.toml
@@ -1,0 +1,7 @@
+# For -Zminimal-versions
+[target.'cfg(any())'.dependencies]
+lazy_static = "1.1"
+paste = "1.0.4"
+log = "0.4.6"
+encoding_rs = "0.8.11"
+bytes = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,3 @@ icondata = "0.3"
 [dependencies]
 icondata_core = "0.1"
 leptos = "0.6"
-
-# For -Zminimal-versions
-[target.'cfg(any())'.dependencies]
-lazy_static = "1.1"
-paste = "1.0.4"
-log = "0.4.6"
-encoding_rs = "0.8.11"
-bytes = "1.2"


### PR DESCRIPTION
Currently, leptos_icons includes in `Cargo.lock`'s dependants the following array:

```toml
dependencies = [
 "bytes",
 "encoding_rs",
 "icondata_core",
 "lazy_static",
 "leptos",
 "log",
 "paste",
]
```

Altough the dependencies are not installed neither shown running `cargo tree`:

```
│   ├── leptos_icons v0.3.1
│   │   ├── icondata_core v0.1.0
│   │   └── leptos v0.6.13 (*)
```

Additionally, these "phantom" dependencies are included in the [crates.io page](https://crates.io/crates/leptos_icons/0.3.1/dependencies).

All of these make the auditing process of dependencies confusing and harder. I'm not sure why the fake target is needed for `-Zminimal-versions` but we can stop releasing that part of the *Cargo.toml* file. 