### PR TITLE
remove duplicate attr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@ pub fn Icon(
             .attr("stroke-linecap", icon.stroke_linecap)
             .attr("stroke-linejoin", icon.stroke_linejoin)
             .attr("stroke-width", icon.stroke_width)
-            .attr("stroke-linecap", icon.stroke_linecap)
             .attr("stroke", icon.stroke)
             .attr("fill", icon.fill.unwrap_or("currentColor"))
             .attr("role", "graphics-symbol")


### PR DESCRIPTION
Recently, I started to use [icondata](https://github.com/carloskiki/icondata) with leptos and yew, and I found they're so good and easy to use.

I also found a duplicate `attr()` for `stroke-linecap` in the `lib.rs`. I am not sure whether it's for an existing issue or not. Maybe we can just remove it?

Thank you for developing `icondata` and `leptos-icons`!
