### PR TITLE
Allow to pass signals to borrowed to sizes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@ pub fn Icon(
     #[prop(into)]
     icon: Signal<icondata_core::Icon>,
     #[prop(into, optional)] style: MaybeProp<String>,
-    #[prop(into, optional)] width: MaybeProp<String>,
-    #[prop(into, optional)] height: MaybeProp<String>,
+    #[prop(into, optional, default=TextProp::from("1em"))] width: TextProp,
+    #[prop(into, optional, default=TextProp::from("1em"))] height: TextProp,
 ) -> impl IntoView {
     move || {
         let icon = icon.get();
@@ -56,8 +56,8 @@ pub fn Icon(
             })
             .attr("x", icon.x)
             .attr("y", icon.y)
-            .attr("width", width.get().unwrap_or_else(|| "1em".to_string()))
-            .attr("height", height.get().unwrap_or_else(|| "1em".to_string()))
+            .attr("width", width.get())
+            .attr("height", height.get())
             .attr("viewBox", icon.view_box)
             .attr("stroke-linecap", icon.stroke_linecap)
             .attr("stroke-linejoin", icon.stroke_linejoin)


### PR DESCRIPTION
Currently, if you try to pass a `Signal<&str>` to `Icon`'s props `width` and `height`, the next error is raised:

```
the trait `From<leptos::prelude::Signal<&str>>` is not implemented for `MaybeProp<std::string::String>`
```

This is not happening for plain `&'static str` because there is a `impl` for `Debug` [here](https://docs.rs/leptos/latest/leptos/prelude/struct.MaybeProp.html#impl-Debug-for-MaybeProp%3CT,+S%3E):

```rust
impl<T, S> Debug for MaybeProp<T, S>
where
    T: Debug + 'static,
```

So better use [`TextProp`](https://docs.rs/leptos/latest/leptos/text_prop/struct.TextProp.html).